### PR TITLE
add angles as dependency to multisense_ros build

### DIFF
--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -16,6 +16,7 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif ()
 
 find_package(ament_cmake REQUIRED)
+find_package(angles REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(multisense_lib REQUIRED)
 find_package(multisense_msgs REQUIRED)
@@ -38,6 +39,7 @@ add_library(${PROJECT_NAME} src/camera.cpp
                             src/utility.cpp)
 
 ament_target_dependencies(${PROJECT_NAME}
+                         angles
                          geometry_msgs
                          multisense_lib
                          multisense_msgs

--- a/multisense_ros/package.xml
+++ b/multisense_ros/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>yaml-cpp</buildtool_depend>
 
+  <build_depend>angles</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>libopencv-dev</build_depend>
   <build_depend>multisense_lib</build_depend>
@@ -22,6 +23,7 @@
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
 
+  <exec_depend>angles</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>libopencv-dev</exec_depend>
   <exec_depend>multisense_lib</exec_depend>


### PR DESCRIPTION
I build ros2 from source, and I had to modify the ros2.repos file before performing the retrieve and build to include: 

```yaml
  ros2/angles: 
    type: git 
    url: https://github.com/ros/angles.git 
    version: ros2 
  ros2/vision_opencv: 
    type: git 
    url: https://github.com/ros-perception/vision_opencv.git 
    version: foxy 
```

but if I used the apt install method as the docker image you provide I had to include:

`apt-get install ros-foxy-vision-opencv ros-foxy-angles`

this appears to work with foxy and eloquent. 