### PR TITLE
Remove Failing Linting Tests

### DIFF
--- a/multisense_lib/CMakeLists.txt
+++ b/multisense_lib/CMakeLists.txt
@@ -22,20 +22,6 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 add_subdirectory(src)
 


### PR DESCRIPTION
This PR removes the default ament linting, copyright, etc. tests that are in the CMakeLists.txt template file. Without this PR, `colcon test` will fail.

LibMultiSense was not written with these linters in mind, and we have no intention of modifying it to comply with them