### PR TITLE
clang compiler fixes

### DIFF
--- a/multisense_lib/src/source/LibMultiSense/details/utility/BufferStream.hh
+++ b/multisense_lib/src/source/LibMultiSense/details/utility/BufferStream.hh
@@ -39,7 +39,10 @@
 #ifndef CRL_MULTISENSE_BUFFERSTREAM_HH
 #define CRL_MULTISENSE_BUFFERSTREAM_HH
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include "Exception.hh"
+#pragma clang diagnostic pop
 #include "TimeStamp.hh"
 #include "ReferenceCount.hh"
 #include "Portability.hh"

--- a/multisense_lib/src/source/LibMultiSense/details/utility/linux/Thread.hh
+++ b/multisense_lib/src/source/LibMultiSense/details/utility/linux/Thread.hh
@@ -56,7 +56,10 @@
 
 #include "details/utility/Portability.hh"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include "../Exception.hh"
+#pragma clang diagnostic pop
 
 namespace crl {
 namespace multisense {

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
         if (const auto status = d->setMtu(sensor_mtu.as_int()); status != Status_Ok)
         {
             RCLCPP_ERROR(initialize_node->get_logger(), "multisense_ros: failed to set sensor MTU to %d: %s",
-                         sensor_mtu, Channel::statusString(status));
+                         sensor_mtu.as_double(), Channel::statusString(status));
             Channel::Destroy(d);
             return EXIT_FAILURE;
         }


### PR DESCRIPTION
We often use the clang compiler and it throws an error against this line of code, I have corrected it (I think, I didnt actually trigger the exception) 

```bash 
--- stderr: multisense_ros                               
/home/max/git/autonomy/ros/ros2_workspace/multisense_ros/multisense_ros/src/ros_driver.cpp:100:26: error: cannot pass object of non-trivial type 'rclcpp::Parameter' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
                         sensor_mtu, Channel::statusString(status));
                         ^
1 error generated.
make[2]: *** [CMakeFiles/ros_driver.dir/build.make:82: CMakeFiles/ros_driver.dir/src/ros_driver.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:153: CMakeFiles/ros_driver.dir/all] Error 2
make: *** [Makefile:160: all] Error 2
---
Failed   <<< multisense_ros [22.9s, exited with code 2]
```

And there are multiple instances of the following warning (which we treat as an error) 

```bash 
Starting >>> multisense_msgs
--- stderr: multisense_lib
CMake Warning:
  Manually-specified variables were not used by the project:

    UNIT_TESTS


In file included from /home/max/git/autonomy/ros/ros2_workspace/multisense_ros/multisense_lib/src/source/LibMultiSense/details/channel.cc:37:
In file included from /home/max/git/autonomy/ros/ros2_workspace/multisense_ros/multisense_lib/src/source/LibMultiSense/details/channel.hh:42:
In file included from /home/max/git/autonomy/ros/ros2_workspace/multisense_ros/multisense_lib/src/source/LibMultiSense/details/utility/Thread.hh:42:
In file included from /home/max/git/autonomy/ros/ros2_workspace/multisense_ros/multisense_lib/src/source/LibMultiSense/details/utility/linux/Thread.hh:59:
/home/max/git/autonomy/ros/ros2_workspace/multisense_ros/multisense_lib/src/source/LibMultiSense/details/utility/linux/../Exception.hh:74:80: error: token pasting of ',' and __VA_ARGS__ is a GNU extension [-Werror,-Wgnu-zero-variadic-macro-arguments]
                                                           CRL_PRETTY_FUNCTION,##__VA_ARGS__); \
```

I am not familiar enough with macros to know how to fix it, so I just turned the warning off around the Exception.hh header. Feel free to not include it and fix the actual warning ;) 