### PR TITLE
Support updated tf2_geometry_msgs header

### DIFF
--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library(${PROJECT_NAME} src/camera.cpp
                             src/pps.cpp
                             src/status.cpp)
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE ROS_DISTOR=$ENV{ROS_DISTRO})
+
 ament_target_dependencies(${PROJECT_NAME}
                          angles
                          Eigen3

--- a/multisense_ros/src/laser.cpp
+++ b/multisense_ros/src/laser.cpp
@@ -36,7 +36,12 @@
 #include <angles/angles.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
+
+#if ROS_DISTRO == foxy
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <multisense_ros/laser.h>
 #include <multisense_ros/parameter_utilities.h>


### PR DESCRIPTION
Fix the following warning:

```
Starting >>> multisense_lib
Starting >>> multisense_msgs
Finished <<< multisense_lib [4.58s]                                     
Finished <<< multisense_msgs [4.69s]                  
Starting >>> multisense_ros
--- stderr: multisense_ros                                
In file included from /home/ros2/ros2_ws/src/multisense_ros/src/laser.cpp:39:
/opt/ros/humble/include/tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.h:35:2: warning: #warning This header is obsolete, please include tf2_geometry_msgs/tf2_geometry_msgs.hpp instead [-Wcpp]
   35 | #warning This header is obsolete, please include tf2_geometry_msgs/tf2_geometry_msgs.hpp instead
      |  ^~~~~~~
In file included from /home/ros2/ros2_ws/src/multisense_ros/src/camera.cpp:41:
/opt/ros/humble/include/tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.h:35:2: warning: #warning This header is obsolete, please include tf2_geometry_msgs/tf2_geometry_msgs.hpp instead [-Wcpp]
   35 | #warning This header is obsolete, please include tf2_geometry_msgs/tf2_geometry_msgs.hpp instead
      |  ^~~~~~~
---
Finished <<< multisense_ros [16.2s]
```