### PR TITLE
Support updated image_geometry and tf2_geometry_msgs headers

### DIFF
--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(multisense_lib REQUIRED)
 find_package(multisense_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(ros_environment REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(stereo_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -42,6 +43,8 @@ add_library(${PROJECT_NAME} src/camera.cpp
                             src/point_cloud_utilities.cpp
                             src/pps.cpp
                             src/status.cpp)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE ROS_DISTRO=$ENV{ROS_DISTRO})
 
 ament_target_dependencies(${PROJECT_NAME}
                          angles

--- a/multisense_ros/CMakeLists.txt
+++ b/multisense_ros/CMakeLists.txt
@@ -44,7 +44,8 @@ add_library(${PROJECT_NAME} src/camera.cpp
                             src/pps.cpp
                             src/status.cpp)
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE ROS_DISTRO=$ENV{ROS_DISTRO})
+string(TOUPPER "ROS_$ENV{ROS_DISTRO}" ROS_DISTRO)
+target_compile_definitions(${PROJECT_NAME} PRIVATE ${ROS_DISTRO}=1)
 
 ament_target_dependencies(${PROJECT_NAME}
                          angles

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -38,7 +38,12 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#if (ROS_DISTRO == foxy || ROS_DISTRO == galactic || ROS_DISTRO == humble)
 #include <image_geometry/stereo_camera_model.h>
+#else
+#include <image_geometry/stereo_camera_model.hpp>
+#endif
+
 #include <sensor_msgs/distortion_models.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <stereo_msgs/msg/disparity_image.hpp>

--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -38,7 +38,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#if (ROS_DISTRO == foxy || ROS_DISTRO == galactic || ROS_DISTRO == humble)
+#if defined(ROS_FOXY) || defined(ROS_GALACTIC) || defined(ROS_HUMBLE)
 #include <image_geometry/stereo_camera_model.h>
 #else
 #include <image_geometry/stereo_camera_model.hpp>

--- a/multisense_ros/package.xml
+++ b/multisense_ros/package.xml
@@ -20,6 +20,7 @@
   <build_depend>image-geometry</build_depend>
   <build_depend>multisense_lib</build_depend>
   <build_depend>multisense_msgs</build_depend>
+  <build_depend>ros_environment</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>stereo_msgs</build_depend>

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -38,7 +38,12 @@
 
 #include <Eigen/Geometry>
 #include <sensor_msgs/image_encodings.hpp>
+
+#if (ROS_DISTRO == foxy || ROS_DISTRO == galactic)
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <multisense_msgs/msg/raw_cam_config.hpp>
 #include <multisense_msgs/msg/raw_cam_cal.hpp>

--- a/multisense_ros/src/camera.cpp
+++ b/multisense_ros/src/camera.cpp
@@ -39,7 +39,7 @@
 #include <Eigen/Geometry>
 #include <sensor_msgs/image_encodings.hpp>
 
-#if (ROS_DISTRO == foxy || ROS_DISTRO == galactic)
+#if defined(ROS_FOXY) || defined(ROS_GALACTIC)
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>

--- a/multisense_ros/src/laser.cpp
+++ b/multisense_ros/src/laser.cpp
@@ -37,7 +37,7 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
 
-#if (ROS_DISTRO == foxy || ROS_DISTRO == galactic)
+#if defined(ROS_FOXY) || defined(ROS_GALACTIC)
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>

--- a/multisense_ros/src/laser.cpp
+++ b/multisense_ros/src/laser.cpp
@@ -36,7 +36,12 @@
 #include <angles/angles.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
+
+#if (ROS_DISTRO == foxy || ROS_DISTRO == galactic)
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <multisense_ros/laser.h>
 #include <multisense_ros/parameter_utilities.h>


### PR DESCRIPTION
Based on https://github.com/carnegierobotics/multisense_ros2/pull/25

These `.h` header files no longer exist in `rolling` and probably won't exist in `jazzy`.
Tested with `rolling`. Preprocessor macros also tested with `ROS_DISTRO=foxy`.