### PR TITLE
Make sure the fps change has been accepted by camera before finishing…

### DIFF
--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -166,6 +166,13 @@ private:
     void initalizeParameters(const crl::multisense::image::Config& config);
 
     //
+    // Helper function to verify that an fps change has been accepted by the camera.
+    // FPS Changes can take time on certain versions of camera firmware.
+    // To verify changes have been accepted by the camera we will poll the value
+    // up to 0.5s.
+    crl::multisense::Status verifyFpsChange(const crl::multisense::image::Config& config);
+
+    //
     // Parameter management
 
     OnSetParametersCallbackHandle::SharedPtr paramter_handle_;


### PR DESCRIPTION
Make sure the fps change has been accepted by camera before finishing reconfiguration.
FPS can take the camera time to apply and can result in a failed setting if queried too quickly.
