### PR TITLE
Set default MTU from 7200 to 1500

### DIFF
--- a/multisense_ros/launch/multisense_launch.py
+++ b/multisense_ros/launch/multisense_launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
                                       description='Namespace for this MultiSense instance')
 
     mtu = DeclareLaunchArgument(name='mtu',
-                                default_value='7200',
+                                default_value='1500',
                                 description='Sensor MTU')
 
     ip_address = DeclareLaunchArgument(name='ip_address',

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv)
                    .set__read_only(true)
                    .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER)
                    .set__description("multisense mtu");
-    initialize_node->declare_parameter("sensor_mtu", 7200, mtu_description);
+    initialize_node->declare_parameter("sensor_mtu", 1500, mtu_description);
 
     rcl_interfaces::msg::ParameterDescriptor tf_prefix_description;
     tf_prefix_description.set__name("tf_prefix")


### PR DESCRIPTION
NOTE: this should be paired with this PR in LibMultiSense once it lands on main: https://github.com/carnegierobotics/LibMultiSense/pull/165

This PR modifies the default mtu from 7200 to 1500. Jumbo frame support regularly trips up users and prevents them from being able to stream. The performance loss between 1500 and 7200 is theoretically in the low single digit percentages, so it is not worth the trouble of setting the default to a value that is difficult to support and usually not necessary

This should significantly improve most user's ability to get a camera running for the first time, and reduce the amount of debugging it takes to understand why a camera will not stream images