### PR TITLE
Add fps as launch parameter

### DIFF
--- a/multisense_ros/launch/multisense_launch.py
+++ b/multisense_ros/launch/multisense_launch.py
@@ -26,7 +26,10 @@ def generate_launch_description():
     ip_address = DeclareLaunchArgument(name='ip_address',
                                        default_value='10.66.171.21',
                                        description='Sensor IP address')
-
+    
+    fps = DeclareLaunchArgument(name='fps',
+                                default_value="30.0",
+                                description='Sensor frame rate')
 
     launch_robot_state_publisher = DeclareLaunchArgument(name='launch_robot_state_publisher',
                                                          default_value='True',
@@ -37,7 +40,8 @@ def generate_launch_description():
                          executable='ros_driver',
                          parameters=[{'sensor_ip': LaunchConfiguration('ip_address'),
                                       'sensor_mtu': LaunchConfiguration('mtu'),
-                                      'tf_prefix': LaunchConfiguration('namespace')}])
+                                      'tf_prefix': LaunchConfiguration('namespace'),
+                                      'fps': LaunchConfiguration('fps')}])
 
     robot_state_publisher = Node(package='robot_state_publisher',
                                  executable='robot_state_publisher',
@@ -55,6 +59,7 @@ def generate_launch_description():
                               namespace,
                               mtu,
                               ip_address,
+                              fps,
                               launch_robot_state_publisher,
                               multisense_ros,
                               robot_state_publisher])

--- a/multisense_ros/launch/multisense_launch.py
+++ b/multisense_ros/launch/multisense_launch.py
@@ -29,7 +29,7 @@ def generate_launch_description():
     
     fps = DeclareLaunchArgument(name='fps',
                                 default_value="30.0",
-                                description='Sensor frame rate')
+                                description='Sensor frame rate per seconds')
 
     launch_robot_state_publisher = DeclareLaunchArgument(name='launch_robot_state_publisher',
                                                          default_value='True',

--- a/multisense_ros/launch/multisense_launch.py
+++ b/multisense_ros/launch/multisense_launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
                                        description='Sensor IP address')
     
     fps = DeclareLaunchArgument(name='fps',
-                                default_value="30.0",
+                                default_value="10.0",
                                 description='Sensor frame rate per seconds')
 
     use_sensor_qos = DeclareLaunchArgument(name='use_sensor_qos',

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -69,9 +69,17 @@ int main(int argc, char** argv)
                          .set__description("tf2 transform prefix");
     initialize_node->declare_parameter("tf_prefix", "multisense", tf_prefix_description);
 
+    rcl_interfaces::msg::ParameterDescriptor fps_description;
+    fps_description.set__name("fps")
+                         .set__read_only(true)
+                         .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_STRING)
+                         .set__description("fps description");
+    initialize_node->declare_parameter("fps", 30.0, fps_description);
+
     rclcpp::Parameter sensor_ip;
     rclcpp::Parameter sensor_mtu;
     rclcpp::Parameter tf_prefix;
+    rclcpp::Parameter fps;
 
     if(!initialize_node->get_parameter("sensor_ip", sensor_ip))
         RCLCPP_ERROR(initialize_node->get_logger(), "multisense_ros: sensor ip address not specified");
@@ -81,6 +89,9 @@ int main(int argc, char** argv)
 
     if(!initialize_node->get_parameter("tf_prefix", tf_prefix))
         RCLCPP_ERROR(initialize_node->get_logger(), "multisense_ros: tf prefix not specified");
+
+    if(!initialize_node->get_parameter("fps", fps))
+        RCLCPP_ERROR(initialize_node->get_logger(), "multisense_ros: fps not specified");
 
     Channel *d = nullptr;
 


### PR DESCRIPTION
This PR add fps config as a launch parameter. Because fps is a common parameter that usually is personalized for each application, it should be possible to set the parameter in the launch to be quickly and easier to personalized the camera config.