### PR TITLE
Use the system default QoS by default

### DIFF
--- a/multisense_ros/include/multisense_ros/camera.h
+++ b/multisense_ros/include/multisense_ros/camera.h
@@ -71,7 +71,8 @@ public:
     Camera(const std::string& node_name,
            const rclcpp::NodeOptions& options,
            crl::multisense::Channel* driver,
-           const std::string& tf_prefix);
+           const std::string& tf_prefix,
+           bool use_sensor_qos);
 
     ~Camera();
 

--- a/multisense_ros/include/multisense_ros/imu.h
+++ b/multisense_ros/include/multisense_ros/imu.h
@@ -53,7 +53,8 @@ public:
     Imu(const std::string& node_name,
         const rclcpp::NodeOptions& options,
         crl::multisense::Channel* driver,
-        const std::string& tf_prefix);
+        const std::string& tf_prefix,
+        bool use_sensor_qos);
 
     ~Imu();
 

--- a/multisense_ros/include/multisense_ros/laser.h
+++ b/multisense_ros/include/multisense_ros/laser.h
@@ -55,7 +55,8 @@ public:
     Laser(const std::string& node_name,
           const rclcpp::NodeOptions& options,
           crl::multisense::Channel* driver,
-          const std::string& tf_prefix);
+          const std::string& tf_prefix,
+          bool use_sensor_qos);
 
     ~Laser();
 

--- a/multisense_ros/include/multisense_ros/pps.h
+++ b/multisense_ros/include/multisense_ros/pps.h
@@ -47,7 +47,7 @@ class Pps : public rclcpp::Node
 {
 public:
 
-    Pps(const std::string& node_name, crl::multisense::Channel* driver);
+    Pps(const std::string& node_name, crl::multisense::Channel* driver, bool use_sensor_qos);
     ~Pps();
 
     void ppsCallback(const crl::multisense::pps::Header& header);

--- a/multisense_ros/include/multisense_ros/status.h
+++ b/multisense_ros/include/multisense_ros/status.h
@@ -47,7 +47,7 @@ class Status : public rclcpp::Node
 {
 public:
 
-    Status(const std::string& node_name, crl::multisense::Channel* driver);
+    Status(const std::string& node_name, crl::multisense::Channel* driver, bool use_sensor_qos);
     ~Status();
 
 private:

--- a/multisense_ros/launch/multisense_launch.py
+++ b/multisense_ros/launch/multisense_launch.py
@@ -27,6 +27,9 @@ def generate_launch_description():
                                        default_value='10.66.171.21',
                                        description='Sensor IP address')
 
+    use_sensor_qos = DeclareLaunchArgument(name='use_sensor_qos',
+                                           default_value='False',
+                                           description='Use the sensor data QoS for publishing')
 
     launch_robot_state_publisher = DeclareLaunchArgument(name='launch_robot_state_publisher',
                                                          default_value='True',
@@ -37,7 +40,8 @@ def generate_launch_description():
                          executable='ros_driver',
                          parameters=[{'sensor_ip': LaunchConfiguration('ip_address'),
                                       'sensor_mtu': LaunchConfiguration('mtu'),
-                                      'tf_prefix': LaunchConfiguration('namespace')}])
+                                      'tf_prefix': LaunchConfiguration('namespace'),
+                                      'use_sensor_qos': LaunchConfiguration('use_sensor_qos')}])
 
     robot_state_publisher = Node(package='robot_state_publisher',
                                  executable='robot_state_publisher',
@@ -55,6 +59,7 @@ def generate_launch_description():
                               namespace,
                               mtu,
                               ip_address,
+                              use_sensor_qos,
                               launch_robot_state_publisher,
                               multisense_ros,
                               robot_state_publisher])

--- a/multisense_ros/src/pps.cpp
+++ b/multisense_ros/src/pps.cpp
@@ -49,12 +49,16 @@ void ppsCB(const pps::Header& header, void* userDataP)
 
 } // anonymous
 
-Pps::Pps(const std::string& node_name, Channel* driver) :
+Pps::Pps(const std::string& node_name, Channel* driver, bool use_sensor_qos):
     Node(node_name),
     driver_(driver)
 {
-    pps_pub_ = create_publisher<builtin_interfaces::msg::Time>(PPS_TOPIC, rclcpp::SensorDataQoS());
-    stamped_pps_pub_ = create_publisher<multisense_msgs::msg::StampedPps>(STAMPED_PPS_TOPIC, rclcpp::SensorDataQoS());
+    const auto default_qos = rclcpp::SystemDefaultsQoS();
+    const rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
+    const auto qos = use_sensor_qos ? sensor_data_qos : default_qos;
+
+    pps_pub_ = create_publisher<builtin_interfaces::msg::Time>(PPS_TOPIC, qos);
+    stamped_pps_pub_ = create_publisher<multisense_msgs::msg::StampedPps>(STAMPED_PPS_TOPIC, qos);
 
     driver_->addIsolatedCallback(ppsCB, this);
 }


### PR DESCRIPTION
In an effort to ensure better initial ROS2 performance, use the system default QoS by default (most likely TCP) rather than the SensorQoS (UDP)