### PR TITLE
Add debug print info for stream starting

### DIFF
--- a/multisense_ros/src/multisense.cpp
+++ b/multisense_ros/src/multisense.cpp
@@ -1322,7 +1322,7 @@ rclcpp::PublisherOptions MultiSense::create_publisher_options(const std::vector<
 
             if (info.current_count >= 1 && (active_topics_.count(topic) == 0 || active_topics_.at(topic) == 0))
             {
-                RCLCPP_INFO(get_logger(), "Registering subscription to %s", topic.c_str());
+                RCLCPP_DEBUG(get_logger(), "Registering subscription to %s", topic.c_str());
                 for (const auto &source : sources)
                 {
                     this->active_streams_[source]++;
@@ -1330,7 +1330,7 @@ rclcpp::PublisherOptions MultiSense::create_publisher_options(const std::vector<
             }
             else if (info.current_count <= 0)
             {
-                RCLCPP_INFO(get_logger(), "Removing subscription to %s", topic.c_str());
+                RCLCPP_DEBUG(get_logger(), "Removing subscription to %s", topic.c_str());
                 for (const auto &source : sources)
                 {
                     this->active_streams_[source]--;
@@ -1346,12 +1346,12 @@ rclcpp::PublisherOptions MultiSense::create_publisher_options(const std::vector<
                 if (count > 0)
                 {
                     start_streams.push_back(stream);
-                    RCLCPP_INFO(get_logger(), "Starting stream: %s", lms::to_string(stream).c_str());
+                    RCLCPP_DEBUG(get_logger(), "Starting stream: %s", lms::to_string(stream).c_str());
                 }
                 else
                 {
                     streams_to_stop.push_back(stream);
-                    RCLCPP_INFO(get_logger(), "Stopping stream: %s", lms::to_string(stream).c_str());
+                    RCLCPP_DEBUG(get_logger(), "Stopping stream: %s", lms::to_string(stream).c_str());
                 }
             }
 

--- a/multisense_ros/src/multisense.cpp
+++ b/multisense_ros/src/multisense.cpp
@@ -1322,6 +1322,7 @@ rclcpp::PublisherOptions MultiSense::create_publisher_options(const std::vector<
 
             if (info.current_count >= 1 && (active_topics_.count(topic) == 0 || active_topics_.at(topic) == 0))
             {
+                RCLCPP_INFO(get_logger(), "Registering subscription to %s", topic.c_str());
                 for (const auto &source : sources)
                 {
                     this->active_streams_[source]++;
@@ -1329,6 +1330,7 @@ rclcpp::PublisherOptions MultiSense::create_publisher_options(const std::vector<
             }
             else if (info.current_count <= 0)
             {
+                RCLCPP_INFO(get_logger(), "Removing subscription to %s", topic.c_str());
                 for (const auto &source : sources)
                 {
                     this->active_streams_[source]--;
@@ -1344,10 +1346,12 @@ rclcpp::PublisherOptions MultiSense::create_publisher_options(const std::vector<
                 if (count > 0)
                 {
                     start_streams.push_back(stream);
+                    RCLCPP_INFO(get_logger(), "Starting stream: %s", lms::to_string(stream).c_str());
                 }
                 else
                 {
                     streams_to_stop.push_back(stream);
+                    RCLCPP_INFO(get_logger(), "Stopping stream: %s", lms::to_string(stream).c_str());
                 }
             }
 


### PR DESCRIPTION
Print debug info when a topic subscription is enabled/disabled and print out the corresponding LMS streams for the topic