### PR TITLE
Fix typo in the namespace for the KS21i xacro name

### DIFF
--- a/multisense_ros/urdf/KS21i/standalone.urdf.xacro
+++ b/multisense_ros/urdf/KS21i/standalone.urdf.xacro
@@ -2,5 +2,5 @@
 <robot name="multisense" xmlns:xacro="http://ros.org/wiki/xacro">
     <xacro:include filename="$(find multisense_ros)/urdf/KS21i/multisenseKS21i.urdf.xacro"/>
 
-    <xacro:multisenseKS21i name="$(arg name) "/>
+    <xacro:multisenseKS21i name="$(arg name)"/>
 </robot>


### PR DESCRIPTION
This added an extra whitespace at the end of the input name, causing the /tf trees to be invalid