### PR TITLE
check number of subscribers with resolved topic

### DIFF
--- a/multisense_ros/include/multisense_ros/multisense.h
+++ b/multisense_ros/include/multisense_ros/multisense.h
@@ -138,7 +138,8 @@ public:
            std::unique_ptr<multisense::Channel> channel,
            const std::string& tf_prefix,
            bool use_image_transport,
-           bool use_sensor_qos);
+           bool use_sensor_qos,
+           bool publish_static_tf);
 
     ~MultiSense();
 

--- a/multisense_ros/include/multisense_ros/multisense.h
+++ b/multisense_ros/include/multisense_ros/multisense.h
@@ -199,8 +199,8 @@ private:
     //
     // Device stream control
 
-    size_t num_subscribers(const rclcpp::Node::SharedPtr &node, const std::string &topic) const;
-    size_t num_subscribers(const rclcpp::Node* node, const std::string &topic) const;
+    size_t num_subscribers(rclcpp::Node::SharedPtr &node, const std::string &topic);
+    size_t num_subscribers(rclcpp::Node* node, const std::string &topic);
     void stop();
 
     //

--- a/multisense_ros/launch/multisense_launch.py
+++ b/multisense_ros/launch/multisense_launch.py
@@ -22,6 +22,7 @@ def multisense_setup(context, *args, **kwargs):
     mtu = LaunchConfiguration('mtu')
     reconnect = LaunchConfiguration('reconnect')
     reconnect_timeout_s = LaunchConfiguration('reconnect_timeout_s')
+    publish_static_tf = LaunchConfiguration('publish_static_tf')
 
     # Params file: normalize and fail loudly if user provided a bad path
     params_file = LaunchConfiguration('params_file').perform(context).strip()
@@ -41,6 +42,7 @@ def multisense_setup(context, *args, **kwargs):
         'tf_prefix': namespace,
         'reconnect': ParameterValue(reconnect, value_type=bool),
         'reconnect_timeout_s': ParameterValue(reconnect_timeout_s, value_type=int),
+        'publish_static_tf': ParameterValue(publish_static_tf, value_type=bool),
     }
 
     node_args = {
@@ -98,6 +100,12 @@ def generate_launch_description():
         description='Timeout in seconds before the driver configures a reconnect'
     )
 
+    publish_static_tf = DeclareLaunchArgument(
+        name='publish_static_tf',
+        default_value='true',  # use lowercase for launch boolean parsing
+        description='Publish static TF for camera optical frames from MultiSense calibration'
+    )
+
     # Declare params_file ONCE (no duplicates)
     params_file_arg = DeclareLaunchArgument(
         name='params_file',
@@ -134,6 +142,7 @@ def generate_launch_description():
         launch_robot_state_publisher,
         reconnect,
         reconnect_timeout_s,
+        publish_static_tf,
         params_file_arg,
         robot_state_publisher,
         OpaqueFunction(function=multisense_setup),

--- a/multisense_ros/src/init_parameters.yaml
+++ b/multisense_ros/src/init_parameters.yaml
@@ -16,6 +16,11 @@ initialization:
       default_value: "multisense"
       read_only: true
       description: "TF2 prefix for this camera"
+  publish_static_tf:
+      type: bool
+      default_value: true
+      read_only: true
+      description: "Publish static TF transforms for the camera optical frames"
   use_image_transport:
       type: bool
       default_value: false

--- a/multisense_ros/src/multisense.cpp
+++ b/multisense_ros/src/multisense.cpp
@@ -1583,12 +1583,12 @@ void MultiSense::publish_status(const multisense::MultiSenseStatus &status)
     status_pub_->publish(std::make_unique<multisense_msgs::msg::Status>(std::move(output)));
 }
 
-size_t MultiSense::num_subscribers(const rclcpp::Node::SharedPtr &node, const std::string &topic) const
+size_t MultiSense::num_subscribers(rclcpp::Node::SharedPtr &node, const std::string &topic)
 {
     return num_subscribers(node.get(), topic);
 }
 
-size_t MultiSense::num_subscribers(const rclcpp::Node* node, const std::string &topic) const
+size_t MultiSense::num_subscribers(rclcpp::Node* node, const std::string &topic)
 {
     const std::string full_topic = node->get_sub_namespace().empty() ? topic : node->get_sub_namespace()  + "/" + topic;
 
@@ -1597,7 +1597,11 @@ size_t MultiSense::num_subscribers(const rclcpp::Node* node, const std::string &
         return 0;
     }
 
-    return node->count_subscribers(full_topic) ;
+    // Resolve through the node's remap rules so subscriber counts are checked against the topic's *actual* 
+    // (possibly remapped) name rather than its default name.
+    const std::string resolved_topic = node->get_node_base_interface()->resolve_topic_or_service_name(full_topic, false);
+
+    return node->count_subscribers(resolved_topic);
 }
 
 void MultiSense::initialize_parameters(const multisense::MultiSenseConfig &config, const multisense::MultiSenseInfo& info)

--- a/multisense_ros/src/multisense.cpp
+++ b/multisense_ros/src/multisense.cpp
@@ -682,7 +682,8 @@ MultiSense::MultiSense(const std::string& node_name,
                std::unique_ptr<multisense::Channel> channel,
                const std::string& tf_prefix,
                bool use_image_transport,
-               bool use_sensor_qos):
+               bool use_sensor_qos,
+               bool publish_static_tf):
     Node(node_name, options),
     channel_(std::move(channel)),
     left_node_(create_sub_node(LEFT)),
@@ -696,7 +697,9 @@ MultiSense::MultiSense(const std::string& node_name,
     frame_id_rectified_right_(tf_prefix + RIGHT_RECTIFIED_FRAME),
     frame_id_rectified_aux_(tf_prefix + AUX_RECTIFIED_FRAME),
     frame_id_imu_(tf_prefix + IMU_FRAME),
-    static_tf_broadcaster_(std::make_shared<tf2_ros::StaticTransformBroadcaster>(*this))
+    static_tf_broadcaster_(publish_static_tf ?
+                           std::make_shared<tf2_ros::StaticTransformBroadcaster>(*this) :
+                           nullptr)
 {
     if (!channel_)
     {
@@ -916,7 +919,10 @@ MultiSense::MultiSense(const std::string& node_name,
     // Publish the static transforms for our camera extrinsics for the left/right/aux frames. We will
     // use the left camera frame as the reference coordinate frame
 
-    publish_static_tf(channel_->get_calibration());
+    if (publish_static_tf)
+    {
+        this->publish_static_tf(channel_->get_calibration());
+    }
 
     procesing_threads_.emplace_back(std::thread(&MultiSense::image_publisher, this));
     procesing_threads_.emplace_back(std::thread(&MultiSense::depth_publisher, this));

--- a/multisense_ros/src/ros_driver.cpp
+++ b/multisense_ros/src/ros_driver.cpp
@@ -83,7 +83,8 @@ int main(int argc, char** argv)
                                                                        std::move(channel),
                                                                        params.tf_prefix,
                                                                        params.use_image_transport,
-                                                                       params.use_sensor_qos);
+                                                                       params.use_sensor_qos,
+                                                                       params.publish_static_tf);
 
             rclcpp::executors::SingleThreadedExecutor executor;
             executor.add_node(sensor);


### PR DESCRIPTION
When topics are remapped at runtime the logic was checking the default path rather than the remapped path so no data would flow