### PR TITLE
Start/stop camera streams only on 0↔nonzero subscriber edges.

### DIFF
--- a/multisense_ros/include/multisense_ros/multisense.h
+++ b/multisense_ros/include/multisense_ros/multisense.h
@@ -220,7 +220,8 @@ private:
     void start_processing_threads(bool enable_stereo_processing);
 
     //
-    // Create publisher options which enable disable sources on active subscriptions
+    // Create publisher options which start/stop camera streams only when a topic's
+    // subscriber count crosses between zero and non-zero (not on every DDS match event)
 
     rclcpp::PublisherOptions create_publisher_options(const std::vector<multisense::DataSource> &sources,
                                                       const std::string &topic);

--- a/multisense_ros/src/multisense.cpp
+++ b/multisense_ros/src/multisense.cpp
@@ -1474,50 +1474,61 @@ rclcpp::PublisherOptions MultiSense::create_publisher_options(const std::vector<
         {
             std::lock_guard<std::mutex> lock{this->stream_mutex_};
 
-            if (info.current_count >= 1 && (active_topics_.count(topic) == 0 || active_topics_.at(topic) == 0))
-            {
-                RCLCPP_DEBUG(get_logger(), "Registering subscription to %s", topic.c_str());
-                for (const auto &source : sources)
-                {
-                    this->active_streams_[source]++;
-                }
-            }
-            else if (info.current_count <= 0)
-            {
-                RCLCPP_DEBUG(get_logger(), "Removing subscription to %s", topic.c_str());
-                for (const auto &source : sources)
-                {
-                    this->active_streams_[source]--;
-                }
-            }
+            const int previous = this->active_topics_.count(topic) ? this->active_topics_.at(topic) : 0;
+            const int current = static_cast<int>(info.current_count);
+            this->active_topics_[topic] = current;
 
-            active_topics_[topic] = info.current_count;
-
+            // Only change camera streams when a topic goes from zero to non-zero subscribers
+            // or the reverse. Re-issuing start/stop for every match event (2->1, 1->2, etc.)
+            // flaps ST25 firmware and is a no-op for S27.
+            std::vector<multisense::DataSource> streams_to_start{};
             std::vector<multisense::DataSource> streams_to_stop{};
-            std::vector<multisense::DataSource> start_streams{};
-            for (const auto &[stream, count] : this->active_streams_)
+
+            if (previous <= 0 && current >= 1)
             {
-                if (count > 0)
+                RCLCPP_INFO(get_logger(), "Subscribers on %s (%d): starting sources", topic.c_str(), current);
+                for (const auto &source : sources)
                 {
-                    start_streams.push_back(stream);
-                    RCLCPP_DEBUG(get_logger(), "Starting stream: %s", lms::to_string(stream).c_str());
+                    const int count = ++this->active_streams_[source];
+                    if (count == 1)
+                    {
+                        streams_to_start.push_back(source);
+                    }
                 }
-                else
+            }
+            else if (previous >= 1 && current <= 0)
+            {
+                RCLCPP_INFO(get_logger(), "No subscribers on %s: stopping sources", topic.c_str());
+                for (const auto &source : sources)
                 {
-                    streams_to_stop.push_back(stream);
-                    RCLCPP_DEBUG(get_logger(), "Stopping stream: %s", lms::to_string(stream).c_str());
+                    auto it = this->active_streams_.find(source);
+                    if (it == this->active_streams_.end())
+                    {
+                        continue;
+                    }
+                    it->second--;
+                    if (it->second <= 0)
+                    {
+                        streams_to_stop.push_back(source);
+                        this->active_streams_.erase(it);
+                    }
                 }
             }
 
-            if (const auto status = this->channel_->stop_streams(streams_to_stop) ; status != lms::Status::OK)
+            if (!streams_to_stop.empty())
             {
-                RCLCPP_ERROR(get_logger(), "Unable to stop streams");
+                if (const auto status = this->channel_->stop_streams(streams_to_stop); status != lms::Status::OK)
+                {
+                    RCLCPP_ERROR(get_logger(), "Unable to stop streams: %s", lms::to_string(status).c_str());
+                }
             }
 
-
-            if (const auto status = this->channel_->start_streams(start_streams) ; status != lms::Status::OK)
+            if (!streams_to_start.empty())
             {
-                RCLCPP_ERROR(get_logger(), "Unable to modify active streams");
+                if (const auto status = this->channel_->start_streams(streams_to_start); status != lms::Status::OK)
+                {
+                    RCLCPP_ERROR(get_logger(), "Unable to start streams: %s", lms::to_string(status).c_str());
+                }
             }
         };
 


### PR DESCRIPTION
## Summary

`create_publisher_options` starts and stops camera TX from a DDS `matched_callback`. Image topics (`left/image_rect`, `aux/image_rect_color`, …) are subscriber-gated; `status` is not.

The old callback updated refcounts on 0→1 / 1→0, then **unconditionally** walked `active_streams_` and called `stop_streams` + `start_streams` for every source with count > 0. That ran on **every** match event, including 1→2 and 2→1.

That is a no-op for S27 in steady state. On ST25 it shows up in camera `lms.log` as `Stopping streams` / `Subscribing` on every extra subscriber, and TX often dies after one frame even though ROS still lists a subscriber.

This change only talks to the camera when a topic’s subscriber count crosses **zero ↔ non-zero**. 1→2 / 2→1 are no-ops. `start_streams` / `stop_streams` run only for sources whose refcount actually became 1 or 0.

## Why `gears_logger` looked matched but ST25 was idle

On marsh_tracer (m2):

| | Publisher (`image_rect`) | `gears_logger` |
|---|---|---|
| Reliability | RELIABLE | RELIABLE (logger default; `KeepLast(depth)`, typically 5) |
| History | KEEP_LAST 1 | KEEP_LAST 5 |
| Durability | VOLATILE | VOLATILE |

QoS is **compatible**. `ros2 topic info` showed `gears_logger` matched. Wire TX on `extravlan12` was still **idle** (~20 pkt/5s) until a CLI `ros2 topic echo|hz|delay` attached. Those tools create another match (1→2), the old callback re-issued stop+start, and it looked like “checking the topic repaired it.”

S27 color had **segmentation + logger** (count ≥ 1 from boot) and stayed streaming (~100k pkt/5s). Same callback, different firmware sensitivity. A live RELIABLE `rclpy` sub on ST25 got **0–1 frames** then silence: count never returned to 0, so the driver never re-armed.

## State transitions

```mermaid
stateDiagram-v2
    [*] --> Idle: no subscribers
    Idle --> Streaming: 0 → N\nstart_streams (refcount 0→1)
    Streaming --> Streaming: N → N±k (N, N+k ≥ 1)\nno camera I/O
    Streaming --> Idle: N → 0\nstop_streams (refcount → 0)
```

| DDS event | Before | After |
|---|---|---|
| 0 → 1 | increment refs, then **stop+start all** sources with count > 0 | `start_streams` only for sources whose refcount became 1 |
| 1 → 2 / 2 → 1 | **stop+start all** active sources again | no-op |
| 1 → 0 | decrement refs, then **stop+start** the remaining map | `stop_streams` only for sources whose refcount hit 0 |

INFO logs: `Subscribers on <topic> (N): starting sources` / `No subscribers on <topic>: stopping sources`. Expect **one** start per topic at launch (logger/segmentation), not a start on every extra `echo`.

## Vehicle evidence (marsh_tracer m2, image with this patch)

- After boot: one `starting sources` per S27 and ST25 topic that had a sub; **no** `stopping sources` on extra matches.
- ST25 wire TX held ~100k–230k pkt/5s with logger only (was ~20 idle).

